### PR TITLE
Migrate to discord.py 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 **/.devcontainer/*
 *.json
 **/__pycache__/*
+.idea

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+aiohttp~=3.8
+discord.py~=2.0
+async-timeout~=4.0

--- a/src/assets/strings.json
+++ b/src/assets/strings.json
@@ -11,7 +11,9 @@
 
   "app_name_publish": "Publish",
 
-  "commands_response_sync": "Commands have been synced.",
+  "commands_response_sync": "Commands are synced.",
+  "commands_response_strings": "Strings are reloaded.",
+  "commands_response_commands": "Commands are reloaded.",
   "commands_error_roles": "You need one of these {1} to use this command: {0}",
 
   "publish_response_verified": "Published in {0}!",

--- a/src/assets/strings.json
+++ b/src/assets/strings.json
@@ -1,0 +1,26 @@
+{
+  "client_name": "Leah",
+  "client_description": "Stardew Valley Discord content showcase bot",
+  "client_login": "Logged in as {0}#{1} ({2})",
+
+  "message_verify": "{0} has posted:\n{1}\n{2}",
+  "message_showcase": "posted in #{0}",
+  "message_gallery": [
+    "Some amazing art by {0}"
+  ],
+
+  "app_name_publish": "Publish",
+
+  "commands_response_sync": "Commands have been synced.",
+  "commands_error_roles": "You need one of these {1} to use this command: {0}",
+
+  "publish_response_verified": "Published in {0}!",
+  "publish_response_curated_self": "Published in {0}! Use this command on the showcase post in that channel to remove it.",
+  "publish_response_remove_self": "Your showcase post has been removed.",
+  "publish_error_curated_other": "You can't publish posts by other users.",
+  "publish_error_remove_other": "You can't remove posts by other users.",
+  "publish_error_user": "You can't publish posts from this user.",
+  "publish_error_channel": "You can't publish posts from this channel.",
+  "publish_error_posted": "This post has already been published.",
+  "publish_error_generic": "Couldn't publish that post."
+}

--- a/src/commands.py
+++ b/src/commands.py
@@ -1,0 +1,28 @@
+# Leah
+# commands.py
+# Written by aquova et al., 2022
+# https://github.com/StardewValleyDiscord/leah
+
+import strings
+import discord
+from discord.ext import commands
+from importlib import reload
+from utils import requires_admin
+
+
+class Commands(commands.Cog):
+    posted = set()
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    @commands.command(name="sync")
+    @commands.check(requires_admin)
+    async def sync(self, message: discord.Message) -> None:
+        await self.bot.sync_guild(message.guild)
+        await message.reply(content=strings.get("commands_response_sync"))
+
+async def setup(bot: commands.Bot) -> None:
+    cog: Commands = Commands(bot)
+    await bot.add_cog(cog)
+    reload(strings)

--- a/src/commands.py
+++ b/src/commands.py
@@ -22,6 +22,19 @@ class Commands(commands.Cog):
         await self.bot.sync_guild(message.guild)
         await message.reply(content=strings.get("commands_response_sync"))
 
+    @commands.command(name="strings")
+    @commands.check(requires_admin)
+    async def reload_strings(self, message: discord.Message) -> None:
+        reload(strings)
+        self.bot.reload_strings()
+        await message.reply(content=strings.get("commands_response_strings"))
+
+    @commands.command(name="commands")
+    @commands.check(requires_admin)
+    async def reload_commands(self, message: discord.Message) -> None:
+        await self.bot.reload_extension(name="commands")
+        await message.reply(content=strings.get("commands_response_commands"))
+
 async def setup(bot: commands.Bot) -> None:
     cog: Commands = Commands(bot)
     await bot.add_cog(cog)

--- a/src/config.py
+++ b/src/config.py
@@ -1,3 +1,8 @@
+# Leah
+# config.py
+# Written by aquova et al., 2022
+# https://github.com/StardewValleyDiscord/leah
+
 import discord, json, strings
 
 CONFIG_PATH = "/private/config.json"

--- a/src/config.py
+++ b/src/config.py
@@ -1,4 +1,4 @@
-import discord, json
+import discord, json, strings
 
 CONFIG_PATH = "/private/config.json"
 with open(CONFIG_PATH) as config_file:
@@ -13,4 +13,6 @@ SHOWCASE_CHAN = cfg['channels']['showcase']
 SHOWCASE_ROLES = cfg['roles']['showcase']
 
 intents: discord.Intents = discord.Intents(**{flag: True for flag in cfg["intents"]})
-client = discord.Client(intents=intents)
+client = discord.Client(
+    intents=intents,
+    description=strings.get("client_description"))

--- a/src/config.py
+++ b/src/config.py
@@ -3,21 +3,25 @@
 # Written by aquova et al., 2022
 # https://github.com/StardewValleyDiscord/leah
 
-import discord, json, strings
+import discord, json
 
-CONFIG_PATH = "/private/config.json"
+# Read config file
+CONFIG_PATH = "./private/config.json"
 with open(CONFIG_PATH) as config_file:
     cfg = json.load(config_file)
 
+# Parse config file
+DISCORD_INTENTS: discord.Intents = discord.Intents(**{flag: True for flag in cfg["intents"]})
 DISCORD_KEY = cfg['discord']
 ART_CHANS = cfg['channels']['listening']
 MOD_CHANS = cfg['channels']['selfcurated']
 VERIFY_CHAN = cfg['channels']['verify']
 GALLERY_CHAN = cfg['channels']['gallery']
 SHOWCASE_CHAN = cfg['channels']['showcase']
+ROLES_CHAN = cfg['channels']['roles']
+ADMIN_ROLES = cfg['roles']['admin']
+VERIFY_ROLES = cfg['roles']['verify']
 SHOWCASE_ROLES = cfg['roles']['showcase']
-
-intents: discord.Intents = discord.Intents(**{flag: True for flag in cfg["intents"]})
-client = discord.Client(
-    intents=intents,
-    description=strings.get("client_description"))
+EXTENSIONS = cfg['extensions']
+COMMAND_PREFIX = cfg['command_prefix']
+GUILDS = [discord.Object(id=guild_id) for guild_id in cfg['guilds']]

--- a/src/config.py
+++ b/src/config.py
@@ -12,5 +12,5 @@ GALLERY_CHAN = cfg['channels']['gallery']
 SHOWCASE_CHAN = cfg['channels']['showcase']
 SHOWCASE_ROLES = cfg['roles']['showcase']
 
-intents = discord.Intents.all()
+intents: discord.Intents = discord.Intents(**{flag: True for flag in cfg["intents"]})
 client = discord.Client(intents=intents)

--- a/src/main.py
+++ b/src/main.py
@@ -1,8 +1,9 @@
 # Leah
 # Written by aquova et al., 2022
 # https://github.com/aquova/leah
-import asyncio
 
+import asyncio
+import strings
 import discord
 from config import client, DISCORD_KEY,\
     ART_CHANS, MOD_CHANS, VERIFY_CHAN, GALLERY_CHAN, SHOWCASE_CHAN,\
@@ -17,9 +18,7 @@ leah = Leah()
 
 @client.event
 async def on_ready():
-    print("Logged in as:")
-    print(client.user.name)
-    print(client.user.id)
+    print(strings.get("client_login").format(client.user.name, client.user.discriminator, client.user.id))
 
 @client.event
 async def on_reaction_add(reaction: discord.Reaction, user: discord.User):
@@ -72,12 +71,12 @@ async def on_message(message: discord.Message):
 async def verify_art(message: discord.Message):
     verify = client.get_channel(VERIFY_CHAN)
     for img in message.attachments:
-        await verify.send(f"<@{message.author.id}> has posted:\n{message.content}\n{img.url}")
+        await verify.send(strings.get("title_verify").format(f"<@{message.author.id}>", message.content, img.url))
 
 async def publish_art(message: discord.Message):
     gallery = client.get_channel(GALLERY_CHAN)
     user = message.mentions[0]
-    title = f"Some amazing art by {user}"
+    title = strings.get("title_gallery").format(user)
     split = message.content.split('\n')
     text = split[-2]
     embed = discord.Embed(title=title, type="rich", color=user.color, description=text)
@@ -87,8 +86,8 @@ async def publish_art(message: discord.Message):
 async def publish_mod(message: discord.Message, reaction: discord.Reaction):
     channel = client.get_channel(SHOWCASE_CHAN)
     user = message.author
-    title = f"{reaction.emoji} posted in #{str(message.channel)}"
-    text = f"{message.content}"
+    title = strings.get("title_showcase").format(reaction.emoji, str(message.channel))
+    text = message.content
     embed = discord.Embed(title=title, description=text, type="rich", color=user.color)
 
     # Include original embedded content

--- a/src/main.py
+++ b/src/main.py
@@ -52,7 +52,7 @@ async def on_message(message: discord.Message) -> None:
     if message.channel.id in ART_CHANS:
         await verify_art(message=message)
 
-@bot.tree.context_menu(name="Publish", guilds=GUILDS)
+@bot.tree.context_menu(name=strings.get("app_name_publish"), guilds=GUILDS)
 async def command_publish(interaction: discord.Interaction, message: discord.Message):
     """
     Reposts a message from a self-curated or verification channel as a formatted embed to a showcase or gallery channel,

--- a/src/main.py
+++ b/src/main.py
@@ -9,6 +9,7 @@ import discord
 from discord.ext import commands
 from config import COMMAND_PREFIX, EXTENSIONS, GUILDS, DISCORD_KEY, DISCORD_INTENTS, \
     ART_CHANS, MOD_CHANS, VERIFY_CHAN, GALLERY_CHAN, SHOWCASE_CHAN, VERIFY_ROLES, SHOWCASE_ROLES
+from importlib import reload
 from typing import Optional
 from utils import check_roles, format_roles_error
 
@@ -34,6 +35,9 @@ class Leah(commands.Bot):
 
     async def on_ready(self):
         print(strings.get("client_login").format(bot.user.name, bot.user.discriminator, bot.user.id))
+
+    def reload_strings(self):
+        reload(strings)
 
 
 bot = Leah()
@@ -71,7 +75,7 @@ async def command_publish(interaction: discord.Interaction, message: discord.Mes
 
         # Ignore interactions from users without any of the required roles
         if not check_roles(interaction.user, VERIFY_ROLES):
-            reply = format_roles_error(VERIFY_ROLES)
+            reply = format_roles_error(strings.get("commands_error_roles"), VERIFY_ROLES)
 
         # Ignore messages that have been handled previously
         elif message.id in bot.posted:
@@ -91,7 +95,7 @@ async def command_publish(interaction: discord.Interaction, message: discord.Mes
 
         # Ignore interactions from users without any of the required roles
         if not check_roles(interaction.user, SHOWCASE_ROLES):
-            reply = format_roles_error(SHOWCASE_ROLES)
+            reply = format_roles_error(strings.get("commands_error_roles"), SHOWCASE_ROLES)
 
         # Ignore interactions from users other than the message author
         elif interaction.user != message.author or not isinstance(interaction.user, discord.Member):

--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,7 @@
 # Leah
+# main.py
 # Written by aquova et al., 2022
-# https://github.com/aquova/leah
+# https://github.com/StardewValleyDiscord/leah
 
 import asyncio
 import strings

--- a/src/main.py
+++ b/src/main.py
@@ -3,91 +3,174 @@
 # Written by aquova et al., 2022
 # https://github.com/StardewValleyDiscord/leah
 
-import asyncio
+import random
 import strings
 import discord
-from config import client, DISCORD_KEY,\
-    ART_CHANS, MOD_CHANS, VERIFY_CHAN, GALLERY_CHAN, SHOWCASE_CHAN,\
-    SHOWCASE_ROLES
+from discord.ext import commands
+from config import COMMAND_PREFIX, EXTENSIONS, GUILDS, DISCORD_KEY, DISCORD_INTENTS, \
+    ART_CHANS, MOD_CHANS, VERIFY_CHAN, GALLERY_CHAN, SHOWCASE_CHAN, VERIFY_ROLES, SHOWCASE_ROLES
 from typing import Optional
+from utils import check_roles, format_roles_error
 
-class Leah:
+
+# Bot definition
+class Leah(commands.Bot):
     def __init__(self):
+        super().__init__(
+            command_prefix=COMMAND_PREFIX,
+            intents=DISCORD_INTENTS,
+            description=strings.get("client_description"),
+            allowed_mentions=discord.AllowedMentions.none())
         self.posted = set()
 
-leah = Leah()
+    async def sync_guild(self, guild: discord.Guild):
+        self.tree.copy_global_to(guild=guild)
+        await self.tree.sync(guild=guild)
 
-@client.event
-async def on_ready():
-    print(strings.get("client_login").format(client.user.name, client.user.discriminator, client.user.id))
+    async def setup_hook(self) -> None:
+        # Load all extensions on setup
+        for ext in EXTENSIONS:
+            await self.load_extension(name=ext)
 
-@client.event
-async def on_reaction_add(reaction: discord.Reaction, user: discord.User):
-    # Ignore messages that have been handled previously
-    if reaction.message.id in leah.posted:
-        return
+    async def on_ready(self):
+        print(strings.get("client_login").format(bot.user.name, bot.user.discriminator, bot.user.id))
 
-    # Staff reactions to verification channel posts by this client
-    if reaction.message.channel.id == VERIFY_CHAN:
-        # Ignore reactions to posts not by this client in verification channel
-        if client.user != reaction.message.author:
-            return
 
-        # Publish verified posts to gallery channel
-        await publish_art(message=reaction.message)
+bot = Leah()
 
-    # User reactions to posts in self-curated channel
-    elif reaction.message.channel.id in MOD_CHANS:
-        # Ignore reactions from users other than the message author
-        if user != reaction.message.author:
-            return
 
-        # Ignore reactions from users without any of the required roles
-        if len(SHOWCASE_ROLES) == 0 or len([r for r in user.roles if r.id in SHOWCASE_ROLES]) == 0:
-            return
-
-        # Publish self-curated posts
-        await reaction.message.add_reaction(reaction.emoji)
-        await publish_mod(message=reaction.message, reaction=reaction)
-
-    # User reactions to posts in showcase channel
-    elif reaction.message.channel.id == SHOWCASE_CHAN:
-        # Ignore reactions from users other than the message author
-        if user != await get_original_author(reaction.message):
-            return
-
-        # Remove bulletin posts
-        await reaction.message.delete()
-
-@client.event
-async def on_message(message: discord.Message):
+@bot.listen(name="on_message")
+async def on_message(message: discord.Message) -> None:
+    """
+    For messages in listening channels, reposts a preview to the verification channel.
+    """
     # Ignore all bots
     if message.author.bot:
         return
 
-    # Send posts from creative channel to verification channel
+    # Send posts from listening channels to verification channel
     if message.channel.id in ART_CHANS:
         await verify_art(message=message)
 
-async def verify_art(message: discord.Message):
-    verify = client.get_channel(VERIFY_CHAN)
+@bot.tree.context_menu(name="Publish", guilds=GUILDS)
+async def command_publish(interaction: discord.Interaction, message: discord.Message):
+    """
+    Reposts a message from a self-curated or verification channel as a formatted embed to a showcase or gallery channel,
+    respectively, depending on the channel the original message was posted in.
+    Posts in showcase channels may also be removed with this command.
+    """
+    reply = None
+    success = False      # Reactions are added to messages based on success or failure
+    fail_quietly = True  # Failure reactions are hidden by default
+
+    # Staff interactions on verification channel posts by this bot
+    if message.channel.id == VERIFY_CHAN:
+
+        # Verification errors are shown to all to avoid repeat attempts
+        fail_quietly = False
+
+        # Ignore interactions from users without any of the required roles
+        if not check_roles(interaction.user, VERIFY_ROLES):
+            reply = format_roles_error(VERIFY_ROLES)
+
+        # Ignore messages that have been handled previously
+        elif message.id in bot.posted:
+            reply = strings.get("publish_error_posted")
+
+        # Ignore reactions to invalid posts or posts not by this client in verification channel
+        elif bot.user != message.author or not await publish_art(message=message):
+            reply = strings.get("publish_error_user")
+
+        # Publish verified posts to gallery channel
+        else:
+            reply = strings.get("publish_response_verified").format(f"<#{GALLERY_CHAN}>")
+            success = True
+
+    # User interactions on posts in self-curated channel
+    elif message.channel.id in MOD_CHANS:
+
+        # Ignore interactions from users without any of the required roles
+        if not check_roles(interaction.user, SHOWCASE_ROLES):
+            reply = format_roles_error(SHOWCASE_ROLES)
+
+        # Ignore interactions from users other than the message author
+        elif interaction.user != message.author or not isinstance(interaction.user, discord.Member):
+            reply = strings.get("publish_error_curated_other")
+
+        # Ignore messages that have been handled previously
+        elif message.id in bot.posted:
+            reply = strings.get("publish_error_posted")
+
+        # Publish self-curated posts
+        else:
+            reply = strings.get("publish_response_curated_self").format(f"<#{SHOWCASE_CHAN}>")
+            success = True
+            await publish_mod(message=message)
+
+    # User interactions on posts in showcase channel
+    elif message.channel.id == SHOWCASE_CHAN:
+
+        # Users without a showcase role may still remove any of their posts from the showcase
+
+        # Ignore interactions from users other than the message author
+        if interaction.user != await get_original_author(message):
+            reply = strings.get("publish_error_remove_other")
+
+        # Remove showcase posts
+        else:
+            reply = strings.get("publish_response_remove_self")
+            success = True
+            await message.delete()
+
+    # User interactions on posts in unhandled channels
+    else:
+        reply = strings.get("publish_error_channel")
+
+    # Send a secret reply to the commander
+    if reply is None:
+        reply = strings.get("publish_error_generic")
+    await interaction.response.send_message(reply, ephemeral=True)
+
+    # Add a reaction to the post to show it's been interacted with
+    try:
+        if success or not fail_quietly:
+            await message.add_reaction(strings.emoji_success if success else strings.emoji_failure)
+    except:
+        return
+
+async def verify_art(message: discord.Message) -> None:
+    """
+    Creates a formatted message preview of a message for the bot to send in the verification channel.
+    :param message: The original message from a listening channel.
+    """
+    verify = bot.get_channel(VERIFY_CHAN)
     for img in message.attachments:
-        await verify.send(strings.get("title_verify").format(f"<@{message.author.id}>", message.content, img.url))
+        await verify.send(strings.get("message_verify").format(f"<@{message.author.id}>", message.content, img.url))
 
-async def publish_art(message: discord.Message):
-    gallery = client.get_channel(GALLERY_CHAN)
-    user = message.mentions[0]
-    title = strings.get("title_gallery").format(user)
-    split = message.content.split('\n')
-    text = split[-2]
-    embed = discord.Embed(title=title, type="rich", color=user.color, description=text)
-    embed.set_image(url=split[-1])
-    await send_embed(channel=gallery, embed=embed, message=message)
+async def publish_art(message: discord.Message) -> bool:
+    """
+    Creates a published message with embedded content for the bot to report in the gallery channel.
+    """
+    gallery = bot.get_channel(GALLERY_CHAN)
+    try:
+        member = await message.guild.fetch_member(message.raw_mentions[0])
+        title = random.choice(strings.get("message_gallery")).format(member)
+        split = message.content.split('\n')
+        text = split[-2]
+        embed = discord.Embed(title=title, type="rich", color=member.color, description=text)
+        embed.set_image(url=split[-1])
+        await send_embed(channel=gallery, embed=embed, message=message)
+    except:
+        return False
+    return True
 
-async def publish_mod(message: discord.Message, reaction: discord.Reaction):
-    channel = client.get_channel(SHOWCASE_CHAN)
+async def publish_mod(message: discord.Message) -> None:
+    """
+    Creates a published message with embedded content for the bot to repost in the showcase channel.
+    """
+    channel = bot.get_channel(SHOWCASE_CHAN)
     user = message.author
-    title = strings.get("title_showcase").format(reaction.emoji, str(message.channel))
+    title = strings.get("message_showcase").format(str(message.channel))
     text = message.content
     embed = discord.Embed(title=title, description=text, type="rich", color=user.color)
 
@@ -110,11 +193,25 @@ async def publish_mod(message: discord.Message, reaction: discord.Reaction):
 
     await send_embed(channel=channel, embed=embed, message=message)
 
-async def send_embed(channel: discord.TextChannel, embed: discord.Embed, message: discord.Message):
-    leah.posted.add(message.id)
+async def send_embed(channel: discord.TextChannel, embed: discord.Embed, message: discord.Message) -> None:
+    """
+    Record a message as posted and then send to the given channel.
+    :param channel: The channel in which to send the embed.
+    :param embed: A formatted embed based on some user-created message.
+    :param message: The original message from a listening or self-curated channel.
+    """
+    bot.posted.add(message.id)
     await channel.send(embed=embed)
 
 async def get_original_author(showcase_message: discord.Message) -> Optional[discord.Member]:
+    """
+    Showcase messages are bot-reposts of other user-created messages.
+
+    We can fetch the user who authored the original message by following the jumplink from the repost.
+    :param showcase_message: A message posted in any showcase channel.
+    :return: The original author of a given self-curated showcase message, or None if not found.
+    """
+    # We store a jumplink to the original message in the embed URL, as created in publish_mod()
     split_url = showcase_message.embeds[0].url.split('/')
     original_channel = showcase_message.guild.get_channel(int(split_url[-2]))
     try:
@@ -123,8 +220,6 @@ async def get_original_author(showcase_message: discord.Message) -> Optional[dis
     except discord.DiscordException:
         return None
 
-async def main():
-    async with client:
-        await client.start(DISCORD_KEY)
 
-asyncio.run(main())
+# Run the bot with configured intents
+bot.run(DISCORD_KEY)

--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,7 @@
 # Leah
 # Written by aquova et al., 2022
 # https://github.com/aquova/leah
+import asyncio
 
 import discord
 from config import client, DISCORD_KEY,\
@@ -122,4 +123,8 @@ async def get_original_author(showcase_message: discord.Message) -> Optional[dis
     except discord.DiscordException:
         return None
 
-client.run(DISCORD_KEY)
+async def main():
+    async with client:
+        await client.start(DISCORD_KEY)
+
+asyncio.run(main())

--- a/src/strings.py
+++ b/src/strings.py
@@ -9,5 +9,8 @@ STRINGS_PATH = "./assets/strings.json"
 with open(file=STRINGS_PATH, mode="r", encoding="utf8") as strings_file:
     _data = json.load(strings_file)
 
+emoji_success = "\N{WHITE HEAVY CHECK MARK}"
+emoji_failure = "\N{NEGATIVE SQUARED CROSS MARK}"
+
 def get(__name: str):
     return _data.get(__name)

--- a/src/strings.py
+++ b/src/strings.py
@@ -1,7 +1,7 @@
 # Leah
 # strings.py
 # Written by aquova et al., 2022
-# https://github.com/StardewValleyDiscord/Leah
+# https://github.com/StardewValleyDiscord/leah
 
 import json
 

--- a/src/strings.py
+++ b/src/strings.py
@@ -1,0 +1,13 @@
+# Leah
+# strings.py
+# Written by aquova et al., 2022
+# https://github.com/StardewValleyDiscord/Leah
+
+import json
+
+STRINGS_PATH = "./assets/strings.json"
+with open(file=STRINGS_PATH, mode="r", encoding="utf8") as strings_file:
+    _data = json.load(strings_file)
+
+def get(__name: str):
+    return _data.get(__name)

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,0 +1,35 @@
+# Leah
+# utils.py
+# Written by aquova et al., 2022
+# https://github.com/StardewValleyDiscord/leah
+
+import strings
+import discord
+from discord.ext.commands import Context
+from config import ROLES_CHAN, ADMIN_ROLES
+from typing import Union
+
+def format_roles_error(roles):
+    """
+    :param roles: List of required roles to display in the error message.
+    :return: Formatted error message.
+    """
+    return strings.get("commands_error_roles").format(", ".join([f"<@&{role}>" for role in roles]), f"<#{ROLES_CHAN}>")
+
+def check_roles(user: Union[discord.User, discord.Member], roles) -> bool:
+    """
+    Check roles
+    :param user: A user or member object, where a user that is not a member is ensured not to have any roles.
+    :param roles: A list of role IDs to check for.
+    :return: Whether a user has any of the roles in a given list.
+    """
+    return (isinstance(user, discord.Member)
+            and len(roles) > 0 and len([r for r in user.roles if r.id in roles]) > 0)
+
+def requires_admin(ctx: Context):
+    """
+    Requires admin
+
+    Command check for whether the author doesn't have an admin role.
+    """
+    return check_roles(ctx.message.author, ADMIN_ROLES)

--- a/src/utils.py
+++ b/src/utils.py
@@ -9,12 +9,13 @@ from discord.ext.commands import Context
 from config import ROLES_CHAN, ADMIN_ROLES
 from typing import Union
 
-def format_roles_error(roles):
+def format_roles_error(error, roles):
     """
+    :param error: Unformatted error message.
     :param roles: List of required roles to display in the error message.
     :return: Formatted error message.
     """
-    return strings.get("commands_error_roles").format(", ".join([f"<@&{role}>" for role in roles]), f"<#{ROLES_CHAN}>")
+    return error.format(", ".join([f"<@&{role}>" for role in roles]), f"<#{ROLES_CHAN}>")
 
 def check_roles(user: Union[discord.User, discord.Member], roles) -> bool:
     """


### PR DESCRIPTION
# Summary:
stonks 📈
- Migrate project and requirements to target python~=3.8, discord.py~=2.0.
- Migrate content publishing features from event listeners to contextual commands where applicable.
- Move all text strings to a single data file.
- Add text commands for applying changes at runtime.

# Changes:
## requirements.txt
- Add file.

## main.py
- Migrate Leah from `Client` to `Bot` to support app commands.
- Update bot run process for new async setup.
- Reduce declared intents to those used by the bot.
- Remove reaction emoji icon from showcase posts.
- Add client description.
- Disable mentions in bot messages.
- Add role check for art verification.
- Add documentation to all methods.

## config.py
- New fields:
  - `intents` - Required intents.
  - `guilds` - Guilds for app command syncing.
  - `command_prefix` - Command prefix for low-level text commands, eg. `sync`.
  - `roles.verify` - Roles needed to use art verification features.
  - `roles.admin` - Roles needed to use admin-restricted features.
  - `channels.roles` - Channel mentioned in missing-roles errors.

## utils.py
- Add file.
- New methods:
  - `requires_admin` - Lifted from Governor, shorthand check against admin roles.

## commands.py
- Add file.
- New commands:
  - `sync` - Updates app commands upstream, restricted to admin roles.
  - `strings` - Updates text strings for all commands.
  - `commands` - Updates commands extension with code changes.

## strings.py
- Add file.

## strings.json
- Add file.
- Add entries for all current logs, vanity messages, errors, client info, and command names.