### PR TITLE
Fix showcase embeds not using author's role colour

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -193,7 +193,7 @@ async def publish_art(message: discord.Message) -> bool:
     split = message.content.split("\n")
     # Add original text content
     text = "\n".join(split[1:-2])
-    embed = discord.Embed(title=title, description=text, type="rich", color=author.color)
+    embed = discord.Embed(title=title, description=text, type="rich", colour=author.colour)
     # Add original embedded content
     embed.set_image(url=split[-1])
     # Add jumplink to original message
@@ -223,7 +223,7 @@ async def publish_mod(message: discord.Message) -> None:
     title = strings.get("message_showcase").format(str(message.channel)) if source_embed is None else source_embed.title
     # Add original text content
     text = message.content if source_embed is None or message.content != source_embed.url else f"{source_embed.url}\n\n{source_embed.description}"
-    embed = discord.Embed(title=title, description=text, type="rich", color=author.color)
+    embed = discord.Embed(title=title, description=text, type="rich", colour=author.colour)
     # Add original embedded content
     if url is not None:
         embed.set_image(url=url)

--- a/src/main.py
+++ b/src/main.py
@@ -208,7 +208,7 @@ async def publish_mod(message: discord.Message) -> None:
     Creates a published message with embedded content for the bot to repost in the showcase channel.
     """
     channel = bot.get_channel(SHOWCASE_CHAN)
-    author = message.author
+    author = await message.guild.fetch_member(message.author.id)
     source_embed = None
     # Check for linked content
     url = None

--- a/src/utils.py
+++ b/src/utils.py
@@ -25,7 +25,7 @@ def check_roles(user: Union[discord.User, discord.Member], roles: List[discord.R
     :return: Whether a user has any of the roles in a given list.
     """
     return (isinstance(user, discord.Member)
-            and len(roles) > 0 and len([r for r in user.roles if r.id in roles]) > 0)
+            and len(roles) > 0 and len([r for r in user.roles if r.id in roles or r.id == ADMIN_ROLE]) > 0)
 
 def requires_admin(ctx: Context) -> bool:
     """


### PR DESCRIPTION
Note: we still use `fetch_member` over `get_member` as I'm not sure if clearing the message/member cache will lead to dud references?